### PR TITLE
RFR: Adding decrement and timing stats decorator

### DIFF
--- a/teeth_overlord/stats.py
+++ b/teeth_overlord/stats.py
@@ -157,3 +157,31 @@ def timer_stat(key):
                 return ret
         return wrapper
     return timer_decorator
+
+
+class TimerStat(object):
+    """Context manager to send the how long code takes to run to the
+    stats_client. This is useful if there's a critical section of code you want
+    to measure, instead of the entire function::
+
+            with TimerStat('somestat'):
+                do_cool_stuff()
+
+    """
+    def __init__(self, client, name):
+        self.name = name
+        self.client = client
+        self.start = 0
+
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, type, value, traceback):
+        end = time.time()
+        if type is None:
+            status = 'success'
+        else:
+            # Exception raised
+            status = 'error'
+        self.client.timing('{}.{}'.format(self.name, status), end - self.start)
+        # No return means exceptions get raised normally.

--- a/teeth_overlord/stats.py
+++ b/teeth_overlord/stats.py
@@ -148,11 +148,11 @@ def timer_stat(key):
             try:
                 ret = func(self, *args, **kwargs)
             except Exception:
-                dt = int((time.time() - start) * 1000)
+                dt = int((time.time() - start))
                 client.timing('{}.error'.format(key), dt)
                 raise
             else:
-                dt = int((time.time() - start) * 1000)
+                dt = int((time.time() - start))
                 client.timing('{}.success'.format(key), dt)
                 return ret
         return wrapper

--- a/teeth_overlord/tests/unit/stats.py
+++ b/teeth_overlord/tests/unit/stats.py
@@ -94,7 +94,7 @@ class StatsClientTestCase(unittest.TestCase):
     @mock.patch('time.time')
     def test_success_timing_stat(self, time_mock, sleep_mock):
         sleep_mock.return_value = None
-        time_mock.side_effects = [10, 15]
+        time_mock.side_effect = [10, 15]
         self.some_object.sleep_func(1)
         args = self.mock_stats_client.timing.call_args[0]
         self.assertEqual(args[0], 'somestat.success')
@@ -104,7 +104,7 @@ class StatsClientTestCase(unittest.TestCase):
     @mock.patch('time.time')
     def test_error_timing_stat(self, time_mock, sleep_mock):
         sleep_mock.return_value = None
-        time_mock.side_effects = [10, 11]
+        time_mock.side_effect = [10, 15]
         with self.assertRaises(SpecificException):
             self.some_object.sleep_error_func(1)
         args = self.mock_stats_client.timing.call_args[0]

--- a/teeth_overlord/tests/unit/stats.py
+++ b/teeth_overlord/tests/unit/stats.py
@@ -111,6 +111,35 @@ class StatsClientTestCase(unittest.TestCase):
         self.assertEqual(args[0], 'somestat.error')
         self.assertEqual(args[1], 5)
 
+    @mock.patch('time.sleep')
+    @mock.patch('time.time')
+    def test_timing_success(self, time_mock, sleep_mock):
+        timer = stats.TimerStat(self.mock_stats_client, 'somestat')
+        sleep_mock.return_value = None
+        time_mock.side_effect = [10, 15]
+
+        with timer:
+            time.sleep(1)
+
+        args = self.mock_stats_client.timing.call_args[0]
+        self.assertEqual(args[0], 'somestat.success')
+        self.assertEqual(args[1], 5)
+
+    @mock.patch('time.sleep')
+    @mock.patch('time.time')
+    def test_timing_error(self, time_mock, sleep_mock):
+        sleep_mock.return_value = None
+        time_mock.side_effect = [10, 15]
+        timer = stats.TimerStat(self.mock_stats_client, 'somestat')
+
+        with self.assertRaises(SpecificException):
+            with timer:
+                raise SpecificException()
+
+        args = self.mock_stats_client.timing.call_args[0]
+        self.assertEqual(args[0], 'somestat.error')
+        self.assertEqual(args[1], 5)
+
 
 class ConcurrencyGaugeTestCase(unittest.TestCase):
     def test_concurrency_guage(self):

--- a/teeth_overlord/tests/unit/stats.py
+++ b/teeth_overlord/tests/unit/stats.py
@@ -90,20 +90,26 @@ class StatsClientTestCase(unittest.TestCase):
         self.assertRaises(SpecificException, self.some_object.decr_error_func)
         self.mock_stats_client.decr.assert_called_once_with('somestat.error')
 
-    def test_success_timing_stat(self):
+    @mock.patch('time.sleep')
+    @mock.patch('time.time')
+    def test_success_timing_stat(self, time_mock, sleep_mock):
+        sleep_mock.return_value = None
+        time_mock.side_effects = [10, 15]
         self.some_object.sleep_func(1)
         args = self.mock_stats_client.timing.call_args[0]
         self.assertEqual(args[0], 'somestat.success')
-        # Assert the sent value is within 5 milliseconds of 1 sec.
-        self.assertLessEqual(args[1] - 1000, 5)
+        self.assertEqual(args[1], 5)
 
-    def test_error_timing_stat(self):
+    @mock.patch('time.sleep')
+    @mock.patch('time.time')
+    def test_error_timing_stat(self, time_mock, sleep_mock):
+        sleep_mock.return_value = None
+        time_mock.side_effects = [10, 11]
         with self.assertRaises(SpecificException):
             self.some_object.sleep_error_func(1)
         args = self.mock_stats_client.timing.call_args[0]
         self.assertEqual(args[0], 'somestat.error')
-        # Assert the sent value is within 5 milliseconds of 1 sec.
-        self.assertLessEqual(args[1] - 1000, 5)
+        self.assertEqual(args[1], 5)
 
 
 class ConcurrencyGaugeTestCase(unittest.TestCase):


### PR DESCRIPTION
Adding decorators to decrement stats (rollback functions on errors) and a decorator to send the time it takes to run a function to statsd.

I gave it a 5 millisecond variance allowance, because some calls were randomly taking between 2 and 3 milliseconds  extra in some cases.
